### PR TITLE
Fix jason, ex_aws deps conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ by adding `ex_aws_qldb` to your list of dependencies in `mix.exs`:
 def deps do
   [
     {:ex_aws, "~> 2.0"},
-    {:ex_aws_lambda, "~> 2.0"},
+    {:ex_aws_qldb, "~> 0.1"},
     {:poison, "~> 3.0"},
     {:hackney, "~> 1.9"},
   ]

--- a/lib/ex_aws/ion_hash.ex
+++ b/lib/ex_aws/ion_hash.ex
@@ -9,11 +9,8 @@ defmodule ExAws.IonHash do
 
   defp call_python(module, function, args) do
     pid = default_instance()
-
     return = ExAws.ExPython.call_python(pid, module, function, args)
-
     ExAws.ExPython.stop(pid)
-
     return
   end
 

--- a/lib/ex_aws/qldb.ex
+++ b/lib/ex_aws/qldb.ex
@@ -1,8 +1,8 @@
 defmodule ExAws.QLDB do
-  @type pagination :: [
-    {:max_results, binary} |
-    {:next_token, binary}
-  ]
+  @type pagination :: %{
+    next_token: binary(),
+    max_results: binary()
+  }
 
   @actions %{
     create_ledger: :post,
@@ -23,22 +23,10 @@ defmodule ExAws.QLDB do
   }
 
   @spec create_ledger(
-    name :: binary
-  ) :: ExAws.Operation.JSON.t
-  @spec create_ledger(
-    name :: binary,
-    permission_mode :: binary
-  ) :: ExAws.Operation.JSON.t
-  @spec create_ledger(
     name :: binary,
     permission_mode :: binary,
-    deletion_protection :: binary
-  ) :: ExAws.Operation.JSON.t
-  @spec create_ledger(
-    name :: binary,
-    permission_mode :: binary,
-    deletion_protection :: binary,
-    tags :: binary
+    deletion_protection :: boolean(),
+    tags :: map()
   ) :: ExAws.Operation.JSON.t
   def create_ledger(name, permission_mode \\ "ALLOW_ALL", deletion_protection \\ false, tags \\ %{}) do
     data = %{
@@ -92,33 +80,33 @@ defmodule ExAws.QLDB do
       "ExclusiveEndTime" => opts.exclusive_end_time,
       "InclusiveStartTime" => opts.inclusive_start_time,
       "RoleArn" => opts.role_arn,
-      "S3ExportConfiguration" => %{ 
+      "S3ExportConfiguration" => %{
          "Bucket" => opts.s3_bucket,
-         "EncryptionConfiguration" => %{ 
+         "EncryptionConfiguration" => %{
             "KmsKeyArn" => opts.s3_kms_key_arn,
             "ObjectEncryptionType" => opts.object_encryption_type
          },
          "Prefix" => opts.prefix
       }
    }
-    
+
     request(:export_journal_to_s3, data, "/ledgers/#{name}/journal-s3-exports")
   end
 
-  @type get_block_opts :: [
-    {:block_address, binary} |
-    {:digest_tip_address, binary}
-  ]
+  @type get_block_opts :: %{
+    required(:block_address) => binary,
+    required(:digest_tip_address) => binary
+  }
   @spec get_block(
     name :: binary,
     opts :: get_block_opts
   ) :: ExAws.Operation.JSON.t
   def get_block(name, opts) do
     data = %{
-      "BlockAddress" => %{ 
+      "BlockAddress" => %{
          "IonText" => opts.block_address
       },
-      "DigestTipAddress" => %{ 
+      "DigestTipAddress" => %{
          "IonText" => opts.digest_tip_address
       }
    }
@@ -133,21 +121,21 @@ defmodule ExAws.QLDB do
     request(:get_digest, %{}, "/ledgers/#{name}/digest")
   end
 
-  @type get_revision_opts :: [
-    {:block_address, binary} |
-    {:digest_tip_address, binary} |
-    {:document_id, binary}
-  ]
+  @type get_revision_opts :: %{
+    required(:block_address) => binary,
+    required(:digest_tip_address) => binary,
+    required(:document_id) => binary
+  }
   @spec get_revision(
     name :: binary,
-    opts :: get_block_opts
+    opts :: get_revision_opts
   ) :: ExAws.Operation.JSON.t
   def get_revision(name, opts) do
     data = %{
-      "BlockAddress" => %{ 
+      "BlockAddress" => %{
          "IonText" => opts.block_address
       },
-      "DigestTipAddress" => %{ 
+      "DigestTipAddress" => %{
          "IonText" => opts.digest_tip_address
       },
       "DocumentId" => opts.document_id
@@ -214,7 +202,7 @@ defmodule ExAws.QLDB do
 
   @spec untag_resource(
     resource_arn :: binary,
-    tag_keys :: binary
+    tag_keys :: map()
   ) :: ExAws.Operation.JSON.t
   def untag_resource(resource_arn, tag_keys) do
     params = %{
@@ -248,4 +236,3 @@ defmodule ExAws.QLDB do
     })
   end
 end
-

--- a/lib/ex_aws/qldb_session.ex
+++ b/lib/ex_aws/qldb_session.ex
@@ -3,7 +3,7 @@ defmodule ExAws.QLDBSession do
     {:ion_binary, binary} |
     {:ion_text, binary}
   ]
-  
+
   @type start_session_request :: [
     {:ledger_name, binary}
   ]
@@ -30,16 +30,16 @@ defmodule ExAws.QLDBSession do
     {:next_page_token, binary}
   ]
 
-  @type send_command_request :: [
-    {:session_token, binary | nil} |
-    {:start_session, start_session_request | nil} |
-    {:start_transaction, start_transaction_request | nil} |
-    {:end_session, end_session_request | nil} |
-    {:commit_transaction, commit_transaction_request | nil} |
-    {:abort_transaction, abort_transaction_request | nil} |
-    {:execute_statement, execute_statement_request | nil} |
-    {:fetch_page, fetch_page_request | nil}
-  ]
+  @type send_command_request :: %{
+    optional(:session_token) => binary,
+    optional(:start_session) => start_session_request,
+    optional(:start_transaction) => start_transaction_request,
+    optional(:end_session) => end_session_request,
+    optional(:commit_transaction) => commit_transaction_request,
+    optional(:abort_transaction) => abort_transaction_request,
+    optional(:execute_statement) => execute_statement_request,
+    optional(:fetch_page) => fetch_page_request
+  }
 
   @spec send_command(
     request :: send_command_request

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExAws.QLDB.MixProject do
   defp deps do
     [
       {:ex_aws, "~> 2.4"},
-      {:jason, "~> 1.1"},
+      {:jason, "~> 1.4"},
       {:hackney, "~> 1.9"},
       {:erlport, "~> 0.9"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExAws.QLDB.MixProject do
   def project do
     [
       app: :ex_aws_qldb,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
* Updated `jason` version to 1.4.
* `ex_aws` 2.4 now includes `qldb.session` so don't need to use the git dependency.
* Fixed `@type` and `@spec` definitions so they use more recent map syntax, `optional()` and `required()` key specs.
* Updated README to show `ex_aws_qldb` instead of `ex_aws_lambda`.